### PR TITLE
Fix copy button URL fallback to use production domain

### DIFF
--- a/src/app/[npub]/page.tsx
+++ b/src/app/[npub]/page.tsx
@@ -267,7 +267,7 @@ export default async function NpubPage({
               </svg>
               Subscribe to RSS Feed
             </a>
-            <CopyButton url={`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/${npub}/rss.xml`} />
+            <CopyButton url={`${process.env.NEXT_PUBLIC_BASE_URL || 'https://castr.me'}/${npub}/rss.xml`} />
           </div>
         </div>
 


### PR DESCRIPTION
Fixes the copy button functionality that was copying localhost URLs instead of the proper production domain. The copy button now defaults to castr.me when NEXT_PUBLIC_BASE_URL environment variable is not set, ensuring users always get accessible RSS feed URLs.

• Updates fallback URL from localhost:3000 to castr.me
• Ensures copy button works correctly in production
• Maintains backward compatibility with environment variable configuration