### PR TITLE
Add multiple default relays for better redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ npm test
 
 ## Configuration
 
-- Default relay: `wss://relay.nostr.band`
+- Default relays: 
+  - `wss://relay.nostr.band`
+  - `wss://wot.dergigi.com/`
+  - `wss://wot.utxo.one`
+  - `wss://relay.damus.io`
 - Default npub: `npub1n00yy9y3704drtpph5wszen64w287nquftkcwcjv7gnnkpk2q54s73000n`
 
 ## API

--- a/src/services/nostr/NostrService.ts
+++ b/src/services/nostr/NostrService.ts
@@ -16,13 +16,18 @@ export interface NostrProfile {
 
 export class NostrService {
   private ndk: NDK | null = null
-  private readonly defaultRelay = 'wss://relay.nostr.band'
+  private readonly defaultRelays = [
+    'wss://relay.nostr.band',
+    'wss://wot.dergigi.com/',
+    'wss://wot.utxo.one',
+    'wss://relay.damus.io'
+  ]
   private readonly defaultNpub = 'npub1n00yy9y3704drtpph5wszen64w287nquftkcwcjv7gnnkpk2q54s73000n'
 
   async initialize(): Promise<void> {
     if (!this.ndk) {
       this.ndk = new NDK({
-        explicitRelayUrls: [this.defaultRelay],
+        explicitRelayUrls: this.defaultRelays,
       })
       await this.ndk.connect()
     }


### PR DESCRIPTION
This PR replaces the single default relay with an array of four relays to improve reliability and content discovery. The NostrService now connects to multiple relays simultaneously, providing better redundancy if one relay is down and improved content coverage for podcast feed generation.