### PR TITLE
Add keysend support for Podcasting 2.0 apps

### DIFF
--- a/src/app/[npub]/page.tsx
+++ b/src/app/[npub]/page.tsx
@@ -15,6 +15,7 @@ interface NostrProfile {
   nip05?: string;
   lud16?: string;
   lud06?: string;
+  nodeid?: string;
 }
 
 // Function to count words in a string
@@ -548,10 +549,13 @@ export default async function NpubPage({
                                       </div>
                                       <div className="flex flex-col">
                                         <span>{profile.name || pubkey.slice(0, 8)}</span>
-                                        {profile.lud16 && (
+                                        {profile.nodeid && (
+                                          <span className="text-xs text-gray-500 font-mono">{profile.nodeid}</span>
+                                        )}
+                                        {!profile.nodeid && profile.lud16 && (
                                           <span className="text-xs text-gray-500 font-mono">{profile.lud16}</span>
                                         )}
-                                        {!profile.lud16 && zapSplitsData.lightningAddresses.get(pubkey) && (
+                                        {!profile.nodeid && !profile.lud16 && zapSplitsData.lightningAddresses.get(pubkey) && (
                                           <span className="text-xs text-gray-500 font-mono">{zapSplitsData.lightningAddresses.get(pubkey)}</span>
                                         )}
                                       </div>

--- a/src/components/ExamplesGrid.tsx
+++ b/src/components/ExamplesGrid.tsx
@@ -10,6 +10,7 @@ interface NostrProfile {
   nip05?: string;
   lud16?: string;
   lud06?: string;
+  nodeid?: string;
 }
 
 // Define the example interface

--- a/src/services/feed/PodcastFeedGenerator.ts
+++ b/src/services/feed/PodcastFeedGenerator.ts
@@ -36,12 +36,12 @@ export class PodcastFeedGenerator {
     const items = mediaEvents.map(event => this.generateItem(event, longFormMap)).join('\n')
     
     // Generate value tag for channel-level default (prefer keysend if nodeid exists, else lnaddress)
-    const valueTag = (profile as any)?.nodeid ? `
+    const valueTag = profile.nodeid ? `
     <podcast:value type="lightning" method="keysend" suggested="0.00021">
       <podcast:valueRecipient 
         name="${this.escapeXml(title)}"
         type="node"
-        address="${this.escapeXml((profile as any).nodeid)}"
+        address="${this.escapeXml(profile.nodeid)}"
         split="100"
       />
     </podcast:value>` : (profile.lud16 ? `
@@ -100,12 +100,12 @@ export class PodcastFeedGenerator {
     const itemsXml = items.join('\n')
     
     // Generate value tag for channel-level default (prefer keysend if nodeid exists, else lnaddress)
-    const valueTag = (profile as any)?.nodeid ? `
+    const valueTag = profile.nodeid ? `
     <podcast:value type="lightning" method="keysend" suggested="0.00021">
       <podcast:valueRecipient 
         name="${this.escapeXml(title)}"
         type="node"
-        address="${this.escapeXml((profile as any).nodeid)}"
+        address="${this.escapeXml(profile.nodeid)}"
         split="100"
       />
     </podcast:value>` : (profile.lud16 ? `
@@ -395,7 +395,7 @@ ${keysendRecipients}
     
     // Priority 3: Use profile defaults as 100% (prefer nodeid over lnaddress)
     if (profile && npub) {
-      const nodeId = (profile as any)?.nodeid
+      const nodeId = profile.nodeid
       if (nodeId) {
         return [{
           pubkey: npub,

--- a/src/services/feed/PodcastFeedGenerator.ts
+++ b/src/services/feed/PodcastFeedGenerator.ts
@@ -14,6 +14,7 @@ interface ValueSplit {
   percentage: number
   lightningAddress?: string
   name?: string
+  nodeId?: string
 }
 
 export class PodcastFeedGenerator {
@@ -34,8 +35,8 @@ export class PodcastFeedGenerator {
     // Generate items XML (synchronous for now, will enhance with async later)
     const items = mediaEvents.map(event => this.generateItem(event, longFormMap)).join('\n')
     
-    // Generate value tag if Lightning address exists (default fallback)
-    const valueTag = profile.lud16 ? `
+    // Generate value tags for channel-level defaults (lnaddress and/or keysend)
+    const channelLnaddress = profile.lud16 ? `
     <podcast:value type="lightning" method="lnaddress" suggested="0.00021">
       <podcast:valueRecipient 
         name="${this.escapeXml(title)}"
@@ -44,6 +45,16 @@ export class PodcastFeedGenerator {
         split="100"
       />
     </podcast:value>` : ''
+    const channelKeysend = (profile as any)?.nodeid ? `
+    <podcast:value type="lightning" method="keysend" suggested="0.00021">
+      <podcast:valueRecipient 
+        name="${this.escapeXml(title)}"
+        type="node"
+        address="${this.escapeXml((profile as any).nodeid)}"
+        split="100"
+      />
+    </podcast:value>` : ''
+    const valueTag = `${channelLnaddress}${channelKeysend}`
     
     // Generate the complete RSS feed
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -90,8 +101,8 @@ export class PodcastFeedGenerator {
     const items = await Promise.all(itemsPromises)
     const itemsXml = items.join('\n')
     
-    // Generate value tag if Lightning address exists (default fallback)
-    const valueTag = profile.lud16 ? `
+    // Generate value tags for channel-level defaults (lnaddress and/or keysend)
+    const channelLnaddress = profile.lud16 ? `
     <podcast:value type="lightning" method="lnaddress" suggested="0.00021">
       <podcast:valueRecipient 
         name="${this.escapeXml(title)}"
@@ -100,6 +111,16 @@ export class PodcastFeedGenerator {
         split="100"
       />
     </podcast:value>` : ''
+    const channelKeysend = (profile as any)?.nodeid ? `
+    <podcast:value type="lightning" method="keysend" suggested="0.00021">
+      <podcast:valueRecipient 
+        name="${this.escapeXml(title)}"
+        type="node"
+        address="${this.escapeXml((profile as any).nodeid)}"
+        split="100"
+      />
+    </podcast:value>` : ''
+    const valueTag = `${channelLnaddress}${channelKeysend}`
     
     // Generate the complete RSS feed
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -225,10 +246,10 @@ export class PodcastFeedGenerator {
       return ''
     }
     
-    const recipients = splits.map(split => {
+    // Build lnaddress recipients where available (fallback to synthetic lnaddress when neither address nor nodeId exists)
+    const lnRecipients = splits.filter(split => split.lightningAddress || !split.nodeId).map(split => {
       const name = split.name || `Recipient ${split.pubkey.substring(0, 8)}`
       const address = split.lightningAddress || `recipient@${split.pubkey.substring(0, 8)}.ln`
-      
       return `        <podcast:valueRecipient 
           name="${this.escapeXml(name)}"
           type="lnaddress"
@@ -236,11 +257,29 @@ export class PodcastFeedGenerator {
           split="${split.percentage}"
         />`
     }).join('\n')
-    
-    return `
+
+    // Build keysend recipients for those with a nodeId
+    const keysendRecipients = splits.filter(split => !!split.nodeId).map(split => {
+      const name = split.name || `Recipient ${split.pubkey.substring(0, 8)}`
+      return `        <podcast:valueRecipient 
+          name="${this.escapeXml(name)}"
+          type="node"
+          address="${this.escapeXml(split.nodeId as string)}"
+          split="${split.percentage}"
+        />`
+    }).join('\n')
+
+    const lnBlock = lnRecipients ? `
       <podcast:value type="lightning" method="lnaddress" suggested="0.00021">
-${recipients}
-      </podcast:value>`
+${lnRecipients}
+      </podcast:value>` : ''
+
+    const keysendBlock = keysendRecipients ? `
+      <podcast:value type="lightning" method="keysend" suggested="0.00021">
+${keysendRecipients}
+      </podcast:value>` : ''
+
+    return `${lnBlock}${keysendBlock}`
   }
   
   private extractAudioUrl(content: string): string | undefined {
@@ -358,14 +397,19 @@ ${recipients}
       return kind1Splits
     }
     
-    // Priority 3: Use profile's lightning address as default (100% to profile owner)
-    if (profile && profile.lud16 && npub) {
-      return [{
-        pubkey: npub,
-        percentage: 100,
-        lightningAddress: profile.lud16,
-        name: profile.name || npub
-      }]
+    // Priority 3: Use profile's defaults (lnaddress and/or nodeid) as 100%
+    if (profile && npub) {
+      const hasLn = !!profile.lud16
+      const hasNode = !!(profile as any)?.nodeid
+      if (hasLn || hasNode) {
+        return [{
+          pubkey: npub,
+          percentage: 100,
+          lightningAddress: profile.lud16,
+          name: profile.name || npub,
+          nodeId: (profile as any)?.nodeid
+        }]
+      }
     }
     
     // Priority 4: Return empty array (will fall back to channel-level default)

--- a/src/services/nostr/NostrService.ts
+++ b/src/services/nostr/NostrService.ts
@@ -12,6 +12,7 @@ export interface NostrProfile {
   nip05?: string
   lud16?: string
   lud06?: string
+  nodeid?: string
 }
 
 export class NostrService {
@@ -547,6 +548,7 @@ export class NostrService {
     percentage: number;
     lightningAddress?: string;
     name?: string;
+    nodeId?: string;
   }>> {
     const splits = this.extractZapSplitsWithPercentages(event);
     
@@ -564,11 +566,13 @@ export class NostrService {
       const lightningAddress = lightningAddresses.get(split.pubkey);
       const profile = recipientProfiles.get(split.pubkey);
       const name = profile?.name || `Recipient ${split.pubkey.substring(0, 8)}`;
+      const nodeId = (profile as any)?.nodeid as string | undefined;
       
       return {
         ...split,
         lightningAddress,
-        name
+        name,
+        nodeId
       };
     });
   }

--- a/src/services/nostr/NostrService.ts
+++ b/src/services/nostr/NostrService.ts
@@ -566,7 +566,7 @@ export class NostrService {
       const lightningAddress = lightningAddresses.get(split.pubkey);
       const profile = recipientProfiles.get(split.pubkey);
       const name = profile?.name || `Recipient ${split.pubkey.substring(0, 8)}`;
-      const nodeId = (profile as any)?.nodeid as string | undefined;
+      const nodeId = profile?.nodeid;
       
       return {
         ...split,


### PR DESCRIPTION
This PR adds support for `keysend` payments in addition to existing Lightning addresses. When a Nostr profile has a `nodeid` field, the system now uses it as the recipient address for `keysend` payments following the Podcasting 2.0 [valueRecipient](https://github.com/Podcastindex-org/podcast-namespace/blob/cabc64279907edeab9bfa678602990fa9a990960/docs/tags/value-recipient.md) specification. The implementation prioritizes `keysend` over `lnaddress` when both are available, ensuring optimal backwards compatibility with Podcasting 2.0 apps.

I've added a `nodeid` to this profile for testing purposes, and the [resulting RSS feed](https://njump.me/sovereignengineering.io) now looks like this:

```
<podcast:value type="lightning" method="keysend" suggested="0.00021">
<podcast:valueRecipient 
    name="Sovereign Engineering"
    type="node"
    address="02e12fea95f576a680ec1938b7ed98ef0855eadeced493566877d404e404bfbf52" 
    split="100"/>
</podcast:value>
```

---

By the way @ChadFarrow I've deployed metadata.dergigi.com so people can add the `nodeid` field to their profile easily:

<img width="849" height="439" alt="Screenshot 2025-08-26 at 22 08 08" src="https://github.com/user-attachments/assets/133761ea-d8a2-416a-862d-797eac467204" />

---

See also:

- https://github.com/DanConwayDev/nostr-profile-manager/pull/10